### PR TITLE
URL.createObjectURL()

### DIFF
--- a/web/camera.html
+++ b/web/camera.html
@@ -35,7 +35,12 @@
                 audio: false  //不适用音频
             }, function(strem){
                 console.log(strem);
-                video.src = vendorUrl.createObjectURL(strem);
+                try{
+                    video.src = vendorUrl.createObjectURL(strem);
+                    }catch(e){
+                  console.log(e);
+                  video.srcObject = strem;
+                }
                 video.play();
             }, function(error) {
             });

--- a/web/js/fp.js
+++ b/web/js/fp.js
@@ -38,7 +38,12 @@ function open_camera() {
         audio: false  //不适用音频
     }, function (strem) {
         console.log(strem);
-        video.src = vendorUrl.createObjectURL(strem);
+        try {
+            video.src = vendorUrl.createObjectURL(strem);
+        } catch (e) {
+            console.log(e);
+            video.srcObject = strem;
+        }
         video.play();
     }, function (error) {
     });


### PR DESCRIPTION
Fix "Failed to execute 'createObjectURL' on 'URL': No function was found that matched the signature provided."